### PR TITLE
Cocoapods tests

### DIFF
--- a/nuntius.podspec
+++ b/nuntius.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "nuntius"
-  s.version      = "0.0.4"
+  s.version      = "0.0.5"
   s.summary      = "iOS Framework for end-to-end encrypted messages"
   s.description  = <<-DESC
 

--- a/nuntius/Info.plist
+++ b/nuntius/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.4</string>
+	<string>0.0.5</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/nuntiusTests/DoubleRatchetServiceSpec.m
+++ b/nuntiusTests/DoubleRatchetServiceSpec.m
@@ -1,6 +1,6 @@
 /*
  The MIT License (MIT)
- Copyright © 2017 Ivan Rodriguez. All rights reserved.
+ Copyright (c) 2017 Ivan Rodriguez. All rights reserved.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy of this software
  and associated documentation files (the "Software"), to deal in the Software without restriction,

--- a/nuntiusTests/EncryptionServiceSpec.m
+++ b/nuntiusTests/EncryptionServiceSpec.m
@@ -1,6 +1,6 @@
 /*
  The MIT License (MIT)
- Copyright © 2017 Ivan Rodriguez. All rights reserved.
+ Copyright (c) 2017 Ivan Rodriguez. All rights reserved.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy of this software
  and associated documentation files (the "Software"), to deal in the Software without restriction,

--- a/nuntiusTests/TripleDHServiceSpec.m
+++ b/nuntiusTests/TripleDHServiceSpec.m
@@ -1,6 +1,6 @@
 /*
  The MIT License (MIT)
- Copyright © 2017 Ivan Rodriguez. All rights reserved.
+ Copyright (c) 2017 Ivan Rodriguez. All rights reserved.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy of this software
  and associated documentation files (the "Software"), to deal in the Software without restriction,


### PR DESCRIPTION
- Removed copyright symbols (apparently they prevent cocoapods from loading unit-test classes)